### PR TITLE
Implement improved canvas tools

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -1,29 +1,43 @@
-window.onload = function() {
+document.addEventListener('DOMContentLoaded', () => {
     const canvas = document.getElementById('circuitCanvas');
+    if (!canvas) return;
     const ctx = canvas.getContext('2d');
     let drawing = false;
 
-    canvas.addEventListener('mousedown', function(e) {
+    const colorPicker = document.getElementById('colorPicker');
+    const widthInput = document.getElementById('lineWidth');
+    const clearButton = document.getElementById('clearCanvas');
+
+    const getColor = () => (colorPicker ? colorPicker.value : '#000000');
+    const getWidth = () => (widthInput ? parseInt(widthInput.value, 10) || 1 : 1);
+
+    canvas.addEventListener('mousedown', (e) => {
         drawing = true;
         ctx.beginPath();
         ctx.moveTo(e.offsetX, e.offsetY);
     });
 
-    canvas.addEventListener('mousemove', function(e) {
-        if (drawing) {
-            ctx.lineTo(e.offsetX, e.offsetY);
-            ctx.stroke();
-        }
+    canvas.addEventListener('mousemove', (e) => {
+        if (!drawing) return;
+        ctx.strokeStyle = getColor();
+        ctx.lineWidth = getWidth();
+        ctx.lineTo(e.offsetX, e.offsetY);
+        ctx.stroke();
     });
 
-    canvas.addEventListener('mouseup', function() {
+    const stopDrawing = () => {
         drawing = false;
-    });
+    };
 
-    canvas.addEventListener('mouseout', function() {
-        drawing = false;
-    });
-}
+    canvas.addEventListener('mouseup', stopDrawing);
+    canvas.addEventListener('mouseleave', stopDrawing);
+
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+        });
+    }
+});
 
 function saveCanvas() {
     const canvas = document.getElementById('circuitCanvas');

--- a/edit_design.php
+++ b/edit_design.php
@@ -36,38 +36,13 @@ $image_data = base64_encode($image_data);
     </script>
     <script src="canvas.js"></script>
     <script>
-        window.onload = function() {
+        window.addEventListener('DOMContentLoaded', () => {
             const canvas = document.getElementById('circuitCanvas');
             const ctx = canvas.getContext('2d');
-            let drawing = false;
-
             const img = new Image();
             img.src = image_data;
-            img.onload = function() {
-                ctx.drawImage(img, 0, 0);
-            }
-
-            canvas.addEventListener('mousedown', function(e) {
-                drawing = true;
-                ctx.beginPath();
-                ctx.moveTo(e.offsetX, e.offsetY);
-            });
-
-            canvas.addEventListener('mousemove', function(e) {
-                if (drawing) {
-                    ctx.lineTo(e.offsetX, e.offsetY);
-                    ctx.stroke();
-                }
-            });
-
-            canvas.addEventListener('mouseup', function() {
-                drawing = false;
-            });
-
-            canvas.addEventListener('mouseout', function() {
-                drawing = false;
-            });
-        }
+            img.onload = () => ctx.drawImage(img, 0, 0);
+        });
 
         function saveCanvas() {
             const canvas = document.getElementById('circuitCanvas');
@@ -93,6 +68,11 @@ $image_data = base64_encode($image_data);
 <?php include 'header.php'; ?>
 <div class="container">
     <h1>Schaltplan bearbeiten: <?= htmlspecialchars($name) ?></h1>
+    <div class="draw-controls">
+        <label>Farbe: <input type="color" id="colorPicker" value="#000000"></label>
+        <label>Linienbreite: <input type="number" id="lineWidth" value="2" min="1" max="10"></label>
+        <button id="clearCanvas">Canvas löschen</button>
+    </div>
     <canvas id="circuitCanvas" width="800" height="600"></canvas>
     <br>
     <button onclick="saveCanvas()">Schaltplan speichern</button>

--- a/edit_project.php
+++ b/edit_project.php
@@ -89,6 +89,11 @@ $files = array_diff(scandir($directory), array('..', '.'));
         <?php endwhile; ?>
     </table>
     <h2>Schaltplan erstellen/bearbeiten</h2>
+    <div class="draw-controls">
+        <label>Farbe: <input type="color" id="colorPicker" value="#000000"></label>
+        <label>Linienbreite: <input type="number" id="lineWidth" value="2" min="1" max="10"></label>
+        <button id="clearCanvas">Canvas löschen</button>
+    </div>
     <canvas id="circuitCanvas" width="800" height="600"></canvas>
     <br>
     <button onclick="saveCanvas()">Schaltplan speichern</button>

--- a/tools.css
+++ b/tools.css
@@ -23,3 +23,9 @@
     border-radius: 4px;
     font-size: 12px;
 }
+
+.draw-controls {
+    margin-bottom: 10px;
+    display: flex;
+    gap: 10px;
+}


### PR DESCRIPTION
## Summary
- add color, line width and clear controls to drawing pages
- rework canvas.js to respect new controls
- style `.draw-controls` container

## Testing
- `php` linter *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508c13bd888320bdcfafec9d35ae68